### PR TITLE
fix #16 - docToolchain for rendering docs

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -1,0 +1,17 @@
+outputPath = 'build/docs'
+
+// Path where the docToolchain will search for the input files.
+// This path is appended to the docDir property specified in gradle.properties
+// or in the command line, and therefore must be relative to it.
+
+inputPath = 'src/docs';
+
+
+inputFiles = [
+        [file: 'arc42/index.adoc',       formats: ['html','pdf']],
+]
+
+
+taskInputsDirs = ["${inputPath}/images"]
+
+taskInputsFiles = []

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <!-- Plugin description -->
 This unofficial extension integrates [diagrams.net](https://app.diagrams.net/)  (formerly known as draw.io) directly into IntelliJ.
+It supports diagram files with the extensions `.drawio`
 <!-- Plugin description end -->
 
 ## About
@@ -11,6 +12,7 @@ In fact, it is currently only a proof of concept.
 If you like, you can help to evolve it.
 
 ![screenshot](images/drawioscreenshot.jpg)
+
 
 ## References
 

--- a/dtcw
+++ b/dtcw
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+mainConfigFile=config.groovy
+
+# check if CLI, docker or sdkman are installed
+cli=false
+docker=false
+sdkman=false
+if command -v doctoolchain &> /dev/null; then
+    echo "docToolchain as CLI available"
+    cli=true
+fi
+if command -v docker &> /dev/null; then
+    echo "docker available"
+    docker=true
+    if [ "$1" = "docker" ] ; then
+        cli=false
+        echo "force use of docker"
+        unset 1
+    fi
+fi
+if command -v sdk &> /dev/null; then
+    echo "sdkamn available"
+    sdkman=true
+fi
+if [ "$cli" = true ] ; then
+    command="doctoolchain . $1 $2 $3 $4 $5 $6 $7 $8 $9 --info"
+else
+    if [ "$docker" = true ] ; then
+        docker_cmd=$(which docker)
+        echo $docker_cmd
+        command="$docker_cmd run --rm -it --entrypoint /bin/bash -v ${PWD}:/project rdmueller/doctoolchain:rc-1.2.0 -c \"doctoolchain . $1 $2 $3 $4 $5 $6 $7 $8 $9 --info && exit\""
+        echo $command
+    else
+        echo "docToolchain not installed."
+        if [ "$sdkman" = true ] ; then
+            echo "please use sdkman to install docToolchain"
+            echo "$ sdk install doctoolchain 1.2.0-beta"
+            exit
+        else
+            echo "you need docToolchain as CLI-Tool installed or docker."
+            echo "to install docToolchain as CLI-Tool, please install"
+            echo "sdkman and re-run this command."
+            echo "https://sdkman.io/install"
+            echo "$ curl -s "https://get.sdkman.io" | bash"
+            exit
+        fi
+    fi
+fi
+
+bash -cl "$command"

--- a/src/docs/arc42/chapters/06_runtime_view.adoc
+++ b/src/docs/arc42/chapters/06_runtime_view.adoc
@@ -58,11 +58,52 @@ activate intellij
     activate drawio
 ...
 drawio -> webview : jsRequestHandler(configureEvent)
+    activate webview
     webview -> webview : handleEvent(configureEvent)
     webview -> webview : sendMessage(DrawioConfig)
     webview --> drawio : processMessageFromHost(DrawioConfig)
+    deactivate webview
 ...
-drawio -> webview : jsRequestHandler(initEvent)
+drawio -x webview : jsRequestHandler(initializedEvent)
+...
+drawio -> webview : jsRequestHandler(loadEvent)
+    activate webview
+    webview -x webview : handleEvent(loadEvent)
+    deactivate webview
+
 
 ----
 
+== RTS 03: Autosave
+
+[[init-webview]]
+.Init WebView
+[plantuml,rts3,svg]
+----
+database Filesystem as file
+participant DiagramsEditor as editor <<(C,#ADD1B2)>>
+participant DrawioWebView as webview <<(C,#ADD1B2)>>
+participant drawio as drawio
+activate webview
+activate drawio
+activate editor
+...
+drawio -> webview : jsRequestHandler(autosaveEvent)
+    activate webview
+    webview -> webview : handleEvent(autosaveEvent)
+    webview -> webview : _xmlContent.set(event.xml)
+alt filename.endsWith(".xml")
+        webview -> editor :
+        activate editor
+            editor -> file : save(xml)
+        deactivate editor
+else filename.endsWith(".svg")
+        editor -> webview : exportSvg()
+            webview -> webview : sendMessage(exportEvent)
+            webview -> drawio : processMessageFromHost(Export)
+            webview <-- drawio : jsRequestHandler(exportResponse)
+            webview -> webview : promise.setResponse(exportResponse)
+end
+'    deactivate webview
+...
+----

--- a/src/docs/arc42/chapters/06_runtime_view.adoc
+++ b/src/docs/arc42/chapters/06_runtime_view.adoc
@@ -1,0 +1,68 @@
+[[section-runtime-view]]
+== Runtime View
+
+include::../config.adoc[]
+
+The following sequence diagrams will help you to understand the inner workings of the plugin.
+
+=== RTS 01: Init Plugin Editor
+
+[[init-editor]]
+.Init Plugin Editor
+[plantuml,rts1,svg]
+----
+actor User as user
+participant "Intellij" as intellij
+participant DiagramsEditorProvider as editorprovider <<(C,#ADD1B2)>>
+participant DiagramsEditor as editor <<(C,#ADD1B2)>>
+participant DrawioWebView as webview <<(C,#ADD1B2)>>
+'database Filesystem as file
+activate intellij
+user -> intellij: double click\ndiagram file
+  intellij -> editorprovider : accept(filename)
+  intellij <-- editorprovider : true
+  intellij -> editor : instantiate
+    activate editor
+    editor -> webview : instantiate
+    activate webview
+    webview -> drawio : load
+    activate drawio
+user <-- intellij : display editor
+----
+
+<<init-editor>> shows the simplified sequence on how the plugin editor is instantiated.
+While the file extensions for the fileType-plugin are specified directly in the {uri-repo-main}/resources/META-INF/plugin.xml[`plugin.xml`] file, there is a different mechanism for the fileEditor-Plugin.
+Intellij sends `project` and `file` to the {uri-repo-kotlin}/editor/DrawioEditorProvider.kt[``DiagramsEditorProvider``]'s `accept` method.
+This method could now inspect the file and check if it will provide an editor for it.
+In our case, we just check the file extension.
+If `accept()` returns a `true`, IntelliJ will create and Display the {uri-repo-kotlin}/editor/DrawioEditor.kt[``DiagramsEditor``.]
+
+=== RTS 02: Init WebView
+
+In this scenario, we will see how the basic communication between the JavaScript based draw.io and the Kotlin based Plugin works
+
+[[init-webview]]
+.Init WebView
+[plantuml,rts1,svg]
+----
+participant "Intellij" as intellij
+participant DiagramsEditor as editor <<(C,#ADD1B2)>>
+participant DrawioWebView as webview <<(C,#ADD1B2)>>
+'database Filesystem as file
+activate intellij
+  intellij -> editor : instantiate
+    activate editor
+    editor -> webview : instantiate
+    activate webview
+    webview -> drawio : load
+    activate drawio
+...
+drawio -> webview : jsRequestHandler(configureEvent)
+    webview -> webview : handleEvent(configureEvent)
+    webview -> webview : sendMessage(DrawioConfig)
+    webview --> drawio : processMessageFromHost(DrawioConfig)
+...
+drawio -> webview : jsRequestHandler(initEvent)
+
+----
+

--- a/src/docs/arc42/chapters/06_runtime_view.adoc
+++ b/src/docs/arc42/chapters/06_runtime_view.adoc
@@ -43,7 +43,7 @@ In this scenario, we will see how the basic communication between the JavaScript
 
 [[init-webview]]
 .Init WebView
-[plantuml,rts1,svg]
+[plantuml,rts2,svg]
 ----
 participant "Intellij" as intellij
 participant DiagramsEditor as editor <<(C,#ADD1B2)>>

--- a/src/docs/arc42/config.adoc
+++ b/src/docs/arc42/config.adoc
@@ -7,3 +7,8 @@
 
 // where are images located?
 :imagesdir: ./images
+
+:xrefstyle: short
+
+:uri-repo-main: https://github.com/docToolchain/drawio-intellij-plugin/blob/main/src/main
+:uri-repo-kotlin: {uri-repo-main}/kotlin/de/docs_as_co/intellij/plugin/drawio

--- a/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/BaseDrawioWebView.kt
+++ b/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/BaseDrawioWebView.kt
@@ -75,6 +75,7 @@ abstract class BaseDrawioWebView(val lifetime: Lifetime) {
                     val promise = responseMap[message.requestId]!!
                     responseMap.remove(message.requestId)
                     promise.setResult(message)
+                    this.handleResponse(message)
                 }
 
                 if (message is IncomingMessage.Event) {
@@ -132,5 +133,6 @@ abstract class BaseDrawioWebView(val lifetime: Lifetime) {
     }
 
     protected abstract fun handleEvent(event: IncomingMessage.Event)
+    protected abstract fun handleResponse(response: IncomingMessage.Response)
 }
 

--- a/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DiagramsEditor.kt
+++ b/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DiagramsEditor.kt
@@ -25,15 +25,15 @@ class DiagramsEditor(private val project: Project, private val file: VirtualFile
     init {
 
         view.initializedPromise.then {
-            System.out.println("1: "+file.name)
             view.loadXmlLike(file.inputStream.reader().readText())
         }
 
         view.xmlContent.advise(lifetime) { xml ->
-            System.out.println("2: "+file.name)
             if (xml !== null) {
-                if (file.name.endsWith(".svg")) {
-                    println("have to export as svg")
+                val isSVGFile = file.name.endsWith(".svg")
+                val isSVGXML = xml.startsWith("<svg")
+                if ( isSVGFile && (!isSVGXML) ) {
+                    //ignore the xml payload and ask for an exported svg
                     view.exportSvg()
                 } else {
                     ApplicationManager.getApplication().invokeLater {

--- a/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DiagramsEditorProvider.kt
+++ b/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DiagramsEditorProvider.kt
@@ -34,6 +34,6 @@ class DiagramsEditorProvider : FileEditorProvider, DumbAware {
     override fun createEditor(project: Project, file: VirtualFile): FileEditor = DiagramsEditor(project, file)
 
     override fun getEditorTypeId() = "diagrams.net JCEF editor"
-    override fun getPolicy() = FileEditorPolicy.HIDE_DEFAULT_EDITOR
+    override fun getPolicy() = FileEditorPolicy.PLACE_BEFORE_DEFAULT_EDITOR
 }
 

--- a/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DiagramsEditorProvider.kt
+++ b/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DiagramsEditorProvider.kt
@@ -1,0 +1,39 @@
+package de.docs_as_co.intellij.plugin.drawio.editor
+
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.fileEditor.*
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.runNonUndoableWriteAction
+import com.jetbrains.rd.util.lifetime.LifetimeDefinition
+import java.beans.PropertyChangeListener
+import javax.swing.JComponent
+
+class DiagramsEditorProvider : FileEditorProvider, DumbAware {
+    /**
+     * accept is called whenever IntelliJ opens an editor
+     * if accept return true, IntelliJ will open an instance of this editor
+     */
+    override fun accept(project: Project, file: VirtualFile): Boolean {
+        if (file.isDirectory || !file.exists()) {
+            return false;
+        }
+        val extensions = "drawio;drawio.svg;dio;dio.svg"
+        extensions.split(";").forEach() {
+            if (file.name.endsWith("."+it)) {
+                return true
+            }
+        }
+        return false
+    }
+
+    override fun createEditor(project: Project, file: VirtualFile): FileEditor = DiagramsEditor(project, file)
+
+    override fun getEditorTypeId() = "diagrams.net JCEF editor"
+    override fun getPolicy() = FileEditorPolicy.HIDE_DEFAULT_EDITOR
+}
+

--- a/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DrawioWebMessages.kt
+++ b/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DrawioWebMessages.kt
@@ -21,7 +21,7 @@ sealed class OutgoingMessage {
                 val XMLSVG = "xmlsvg"
             }
 
-            val action = "setTheme"
+            val action = "export"
         }
     }
 

--- a/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DrawioWebView.kt
+++ b/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DrawioWebView.kt
@@ -15,6 +15,7 @@ class DrawioWebView(lifetime: Lifetime) : BaseDrawioWebView(lifetime) {
     val xmlContent: IPropertyView<String?> = _xmlContent
 
     override fun handleEvent(event: IncomingMessage.Event) {
+
         when (event) {
             is IncomingMessage.Event.Initialized -> {
                 _initializedPromise.setResult(Unit)
@@ -37,5 +38,8 @@ class DrawioWebView(lifetime: Lifetime) : BaseDrawioWebView(lifetime) {
     fun loadXmlLike(xmlLike: String) {
         _xmlContent.set(null) // xmlLike is not xml
         send(OutgoingMessage.Event.Load(xmlLike, 1))
+    }
+    fun exportSvg() {
+        send(OutgoingMessage.Request.Export(OutgoingMessage.Request.Export.XMLSVG))
     }
 }

--- a/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DrawioWebView.kt
+++ b/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DrawioWebView.kt
@@ -5,6 +5,7 @@ import com.jetbrains.rd.util.reactive.IPropertyView
 import com.jetbrains.rd.util.reactive.Property
 import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
+import java.util.*
 
 class DrawioWebView(lifetime: Lifetime) : BaseDrawioWebView(lifetime) {
     private val _initializedPromise = AsyncPromise<Unit>()
@@ -35,6 +36,16 @@ class DrawioWebView(lifetime: Lifetime) : BaseDrawioWebView(lifetime) {
         }
     }
 
+    override fun handleResponse(response: IncomingMessage.Response) {
+        when(response) {
+            is IncomingMessage.Response.Export -> {
+                val payload = response.data.split(",")[1]
+                val decodedBytes = Base64.getDecoder().decode(payload)
+                val svg = String(decodedBytes)
+                _xmlContent.set(svg)
+            }
+        }
+    }
     fun loadXmlLike(xmlLike: String) {
         _xmlContent.set(null) // xmlLike is not xml
         send(OutgoingMessage.Event.Load(xmlLike, 1))

--- a/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/language.kt
+++ b/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/language.kt
@@ -8,7 +8,7 @@ object DiagramsNet : Language("Diagrams.net")
 
 object DiagramsNetFileType : LanguageFileType(DiagramsNet) {
     override fun getName() = "Diagrams.net Diagram"
-    override fun getDescription() = "Simple language file"
+    override fun getDescription() = "Diagrams.net Diagram File"
     override fun getDefaultExtension() = "drawio"
     override fun getIcon() = DiagramsNetIcon.FILE
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,7 +8,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <!-- Add your extensions here -->
         <fileType name="Diagrams.net Diagram" implementationClass="de.docs_as_co.intellij.plugin.drawio.DiagramsNetFileType"
-                  fieldName="INSTANCE" language="Diagrams.net" extensions="drawio"/>
+                  fieldName="INSTANCE" language="Diagrams.net" extensions="drawio;drawio.svg;drawio.png;drawio.xml;dio;dio.svg;dio.png;dio.xml"/>
         <fileEditorProvider implementation="de.docs_as_co.intellij.plugin.drawio.editor.DiagramsEditorProvider" ></fileEditorProvider>
     </extensions>
 


### PR DESCRIPTION
just added a config and the docToolchain wrapper `dtcw`

you can now render the docs with

    ./dtcw generateHTML

the wrapper tries to find out if you have a local copy of docToolchain or if it should use docker.