### PR TITLE
added docToolchain as wrapper

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -1,0 +1,17 @@
+outputPath = 'build/docs'
+
+// Path where the docToolchain will search for the input files.
+// This path is appended to the docDir property specified in gradle.properties
+// or in the command line, and therefore must be relative to it.
+
+inputPath = 'src/docs';
+
+
+inputFiles = [
+        [file: 'arc42/index.adoc',       formats: ['html','pdf']],
+]
+
+
+taskInputsDirs = ["${inputPath}/images"]
+
+taskInputsFiles = []

--- a/dtcw
+++ b/dtcw
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+mainConfigFile=config.groovy
+
+# check if CLI, docker or sdkman are installed
+cli=false
+docker=false
+sdkman=false
+if command -v doctoolchain &> /dev/null; then
+    echo "docToolchain as CLI available"
+    cli=true
+fi
+if command -v docker &> /dev/null; then
+    echo "docker available"
+    docker=true
+    if [ "$1" = "docker" ] ; then
+        cli=false
+        echo "force use of docker"
+        unset 1
+    fi
+fi
+if command -v sdk &> /dev/null; then
+    echo "sdkamn available"
+    sdkman=true
+fi
+if [ "$cli" = true ] ; then
+    command="doctoolchain . $1 $2 $3 $4 $5 $6 $7 $8 $9 --info"
+else
+    if [ "$docker" = true ] ; then
+        docker_cmd=$(which docker)
+        echo $docker_cmd
+        command="$docker_cmd run --rm -it --entrypoint /bin/bash -v ${PWD}:/project rdmueller/doctoolchain:rc-1.2.0 -c \"doctoolchain . $1 $2 $3 $4 $5 $6 $7 $8 $9 --info && exit\""
+        echo $command
+    else
+        echo "docToolchain not installed."
+        if [ "$sdkman" = true ] ; then
+            echo "please use sdkman to install docToolchain"
+            echo "$ sdk install doctoolchain 1.2.0-beta"
+            exit
+        else
+            echo "you need docToolchain as CLI-Tool installed or docker."
+            echo "to install docToolchain as CLI-Tool, please install"
+            echo "sdkman and re-run this command."
+            echo "https://sdkman.io/install"
+            echo "$ curl -s "https://get.sdkman.io" | bash"
+            exit
+        fi
+    fi
+fi
+
+bash -cl "$command"

--- a/src/test/groovy/de/docs_as_co/intellij/plugin/drawio/editor/DiagramsEditorTest.groovy
+++ b/src/test/groovy/de/docs_as_co/intellij/plugin/drawio/editor/DiagramsEditorTest.groovy
@@ -1,0 +1,25 @@
+package de.docs_as_co.intellij.plugin.drawio.editor
+
+import com.intellij.mock.MockVirtualFileSystem
+import com.intellij.openapi.command.impl.DummyProject
+import spock.lang.Ignore
+import spock.lang.Specification
+
+import javax.swing.JEditorPane
+
+class DiagramsEditorTest extends Specification {
+    @Ignore("needs proper implementation")
+    def "test saveFile()"() {
+        given:
+            def project = DummyProject.getInstance()
+            def vFS = new MockVirtualFileSystem()
+            vFS.file("test.dio.svg","")
+            def file = vFS.findFileByPath("test.dio.svg")
+            def editorProvider = new DiagramsEditorProvider()
+            def editor = new DiagramsEditor(project, file)
+        when:
+            editor.saveFile("<test />")
+        then:
+            file.content == "<test />"
+    }
+}


### PR DESCRIPTION
execute

    ./dtcw generateHTML

to build the docs. The wrapper check if docToolchains is already installed as CLI via sdkman ot if docker is available to use the dockerized version.

Please ignore the test.