### PR TITLE
fix #15 png handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ gradle-app.setting
 # Once you use this, check in the file
 # More information: https://www.jetbrains.com/​help/idea/required-plugin.html
 !/.idea/externalDependencies.xml
+out

--- a/src/docs/arc42/chapters/03_system_scope_and_context.adoc
+++ b/src/docs/arc42/chapters/03_system_scope_and_context.adoc
@@ -14,3 +14,13 @@ let's use the https://github.com/RicardoNiepel/C4-PlantUML[C4 PlantUML syntax] h
 === Technical Context
 
 TODO
+
+==== draw.io interface
+
+The draw.io interface is messages based and described in the support article https://desk.draw.io/support/solutions/articles/16000042544-embed-mode[Embed Mode].
+
+Example can be found at
+
+* Introduction/Example: https://github.com/jgraph/drawio-html5
+* GitHub Example: https://github.com/jgraph/drawio-github
+* https://support.draw.io/display/DOB/2016/05/09/Simple+draw.io+embedding+walk-through[Simple draw.io embedding walk-through]

--- a/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DiagramsEditor.kt
+++ b/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DiagramsEditor.kt
@@ -29,7 +29,7 @@ class DiagramsEditor(private val project: Project, private val file: VirtualFile
             var payload = ""
             if (file.name.endsWith(".png")) {
                 val binaryContent = file.inputStream.readBytes()
-                payload = Base64.getEncoder().encodeToString(binaryContent)
+                payload = "data:image/png;base64,"+Base64.getEncoder().encodeToString(binaryContent)
             } else {
                 payload = file.inputStream.reader().readText()
             }
@@ -41,10 +41,16 @@ class DiagramsEditor(private val project: Project, private val file: VirtualFile
         view.xmlContent.advise(lifetime) { xml ->
             if (xml !== null) {
                 val isSVGFile = file.name.endsWith(".svg")
+                val isPNGFile = file.name.endsWith(".png")
                 if ( isSVGFile ) {
                     //ignore the xml payload and ask for an exported svg
                     view.exportSvg().then{ svg : String ->
                         saveFile (svg)
+                    }
+                } else if ( isPNGFile ) {
+                    //ignore the xml payload and ask for an exported svg
+                    view.exportPng().then { png: ByteArray ->
+                        savePngFile(png)
                     }
                 } else {
                     saveFile(xml)
@@ -66,7 +72,20 @@ class DiagramsEditor(private val project: Project, private val file: VirtualFile
                 }
             }
         }
-
+    }
+    private fun savePngFile(data : ByteArray) {
+        ApplicationManager.getApplication().invokeLater {
+            ApplicationManager.getApplication().runWriteAction {
+                file.getOutputStream(this).apply {
+                    writer().apply {
+                        write(data)
+                        flush()
+                    }
+                    flush()
+                    close()
+                }
+            }
+        }
     }
     override fun getComponent(): JComponent {
         return view.component

--- a/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DiagramsEditor.kt
+++ b/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DiagramsEditor.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.runNonUndoableWriteAction
 import com.jetbrains.rd.util.lifetime.LifetimeDefinition
 import java.beans.PropertyChangeListener
+import java.util.*
 import javax.swing.JComponent
 
 
@@ -25,7 +26,16 @@ class DiagramsEditor(private val project: Project, private val file: VirtualFile
     init {
 
         view.initializedPromise.then {
-            view.loadXmlLike(file.inputStream.reader().readText())
+            var payload = ""
+            if (file.name.endsWith(".png")) {
+                val binaryContent = file.inputStream.readBytes()
+                payload = Base64.getEncoder().encodeToString(binaryContent)
+            } else {
+                payload = file.inputStream.reader().readText()
+            }
+            System.out.println("=====================")
+            System.out.println(payload)
+            view.loadXmlLike(payload)
         }
 
         view.xmlContent.advise(lifetime) { xml ->

--- a/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DiagramsEditorProvider.kt
+++ b/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DiagramsEditorProvider.kt
@@ -23,7 +23,7 @@ class DiagramsEditorProvider : FileEditorProvider, DumbAware {
             return false;
         }
         //check for the right file extension
-        val extensions = arrayOf(".drawio", ".drawio.svg", ".dio", ".dio.svg")
+        val extensions = arrayOf(".drawio", ".drawio.svg", ".drawio.png", ".dio", ".dio.svg", ".dio.png")
         if (extensions.any { ext -> file.name.endsWith(ext)}) {
             return true
         }

--- a/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DrawioWebView.kt
+++ b/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DrawioWebView.kt
@@ -43,7 +43,7 @@ class DrawioWebView(lifetime: Lifetime) : BaseDrawioWebView(lifetime) {
 
     fun loadPng(payload: ByteArray) {
         _xmlContent.set(null) // xmlLike is not xml
-        val xmlLike = "data:image/png;base64,"+Base64.getEncoder().encodeToString(payload)
+        val xmlLike = "data:image/png;base64," + Base64.getEncoder().encodeToString(payload)
         send(OutgoingMessage.Event.Load(xmlLike, 1))
     }
 

--- a/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DrawioWebView.kt
+++ b/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DrawioWebView.kt
@@ -4,8 +4,7 @@ import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.reactive.IPropertyView
 import com.jetbrains.rd.util.reactive.Property
 import org.jetbrains.concurrency.AsyncPromise
-import org.jetbrains.concurrency.Promise
-import java.util.*
+import org.jetbrains.concurrency.Promiseg
 
 class DrawioWebView(lifetime: Lifetime) : BaseDrawioWebView(lifetime) {
     private val _initializedPromise = AsyncPromise<Unit>()

--- a/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DrawioWebView.kt
+++ b/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DrawioWebView.kt
@@ -44,21 +44,15 @@ class DrawioWebView(lifetime: Lifetime) : BaseDrawioWebView(lifetime) {
         val result = AsyncPromise<String>()
         send(OutgoingMessage.Request.Export(OutgoingMessage.Request.Export.XMLSVG)).then  { response ->
             val data = (response as IncomingMessage.Response.Export).data
-            val payload = data.split(",")[1]
-            val decodedBytes = Base64.getDecoder().decode(payload)
-            val svg = String(decodedBytes)
-            result.setResult(svg)
+            result.setResult(data)
         }
         return result
     }
-    fun exportPng() : Promise<ByteArray> {
-        val result = AsyncPromise<ByteArray>()
+    fun exportPng() : Promise<String> {
+        val result = AsyncPromise<String>()
         send(OutgoingMessage.Request.Export(OutgoingMessage.Request.Export.XMLPNG)).then  { response ->
             val data = (response as IncomingMessage.Response.Export).data
-            val payload = data.split(",")[1]
-            val decodedBytes = Base64.getDecoder().decode(payload)
-            val png = decodedBytes
-            result.setResult(png)
+            result.setResult(data)
         }
         return result
     }

--- a/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DrawioWebView.kt
+++ b/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DrawioWebView.kt
@@ -51,4 +51,15 @@ class DrawioWebView(lifetime: Lifetime) : BaseDrawioWebView(lifetime) {
         }
         return result
     }
+    fun exportPng() : Promise<ByteArray> {
+        val result = AsyncPromise<ByteArray>()
+        send(OutgoingMessage.Request.Export(OutgoingMessage.Request.Export.XMLPNG)).then  { response ->
+            val data = (response as IncomingMessage.Response.Export).data
+            val payload = data.split(",")[1]
+            val decodedBytes = Base64.getDecoder().decode(payload)
+            val png = decodedBytes
+            result.setResult(png)
+        }
+        return result
+    }
 }

--- a/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DrawioWebView.kt
+++ b/src/main/kotlin/de/docs_as_co/intellij/plugin/drawio/editor/DrawioWebView.kt
@@ -4,7 +4,8 @@ import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.reactive.IPropertyView
 import com.jetbrains.rd.util.reactive.Property
 import org.jetbrains.concurrency.AsyncPromise
-import org.jetbrains.concurrency.Promiseg
+import org.jetbrains.concurrency.Promise
+import java.util.*
 
 class DrawioWebView(lifetime: Lifetime) : BaseDrawioWebView(lifetime) {
     private val _initializedPromise = AsyncPromise<Unit>()
@@ -39,6 +40,14 @@ class DrawioWebView(lifetime: Lifetime) : BaseDrawioWebView(lifetime) {
         _xmlContent.set(null) // xmlLike is not xml
         send(OutgoingMessage.Event.Load(xmlLike, 1))
     }
+
+    fun loadPng(payload: ByteArray) {
+        _xmlContent.set(null) // xmlLike is not xml
+        val xmlLike = "data:image/png;base64,"+Base64.getEncoder().encodeToString(payload)
+        send(OutgoingMessage.Event.Load(xmlLike, 1))
+    }
+
+
     fun exportSvg() : Promise<String> {
         val result = AsyncPromise<String>()
         send(OutgoingMessage.Request.Export(OutgoingMessage.Request.Export.XMLSVG)).then  { response ->
@@ -47,11 +56,13 @@ class DrawioWebView(lifetime: Lifetime) : BaseDrawioWebView(lifetime) {
         }
         return result
     }
-    fun exportPng() : Promise<String> {
-        val result = AsyncPromise<String>()
+    fun exportPng() : Promise<ByteArray> {
+        val result = AsyncPromise<ByteArray>()
         send(OutgoingMessage.Request.Export(OutgoingMessage.Request.Export.XMLPNG)).then  { response ->
             val data = (response as IncomingMessage.Response.Export).data
-            result.setResult(data)
+            val payload = data.split(",")[1]
+            val decodedBytes = Base64.getDecoder().decode(payload)
+            result.setResult(decodedBytes)
         }
         return result
     }


### PR DESCRIPTION
this adds correct handling of `(drawio|dio).png`-files to the plugin.
`.png`-files need to be base64 encoded to send them as payload to draw.io